### PR TITLE
Updated the composer manifest to include an exclusions parameter.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,19 @@
     }
     ],
     "require": {
-        "php": ">=5.5",
+        "php": ">=5.6",
         "composer/installers": "v1.2.0"
+    },
+    "archive": {
+        "exclude": [
+          ".editorconfig",
+          ".gitattributes",
+          ".gitignore",
+          "CODE_OF_CONDUCT.md",
+          "CONTRIBUTING.md",
+          "ISSUE_TEMPLATE.md",
+          "PULL_REQUEST_TEMPLATE.md",
+          "/tests"
+        ]
     }
 }


### PR DESCRIPTION
I honestly have no idea if the format is correct but I have added a series of exclusions to the composer manifest as well as bumped the php version to 5.6.

```
    "archive": {
        "exclude": [
          ".editorconfig",
          ".gitattributes",
          ".gitignore",
          "CODE_OF_CONDUCT.md",
          "CONTRIBUTING.md",
          "ISSUE_TEMPLATE.md",
          "PULL_REQUEST_TEMPLATE.md",
          "/tests"
        ]
    }
```